### PR TITLE
Sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ EXTRA_WACS_LIBS ?=
 
 CC = gcc -std=gnu99 -m32
 EMCC = emcc $(CFLAGS) -s WASM=1 -s SIDE_MODULE=1 -s LEGALIZE_JS_FFI=0
+EMCCSB = emcc $(CFLAGS) -s WASM=1 -s NO_FILESYSTEM=1 -s LEGALIZE_JS_FFI=0
 
 WAC_LIBS = m dl $(RL_LIBRARY) $(EXTRA_WAC_LIBS)
 WACE_LIBS = m dl $(RL_LIBRARY) SDL2 SDL2_image GL glut $(EXTRA_WACE_LIBS)
@@ -58,6 +59,8 @@ clean:
 	rm -f *.o *.a wac wace wace-sdl.c wacs \
 	    examples_c/*.js examples_c/*.html \
 	    examples_c/*.wasm examples_c/*.wast \
+	    examples_csb/*.js examples_csb/*.html \
+	    examples_csb/*.wasm examples_csb/*.wast \
 	    examples_wast/*.wasm
 
 ##########################################################
@@ -71,10 +74,21 @@ examples_wast/%.wasm: examples_wast/%.wast
 examples_c/%.wasm: examples_c/%.c
 	$(EMCC) -I examples_c/include -s USE_SDL=2 $< -o $@
 
+
+# Sandboxed C example build rules
+examples_csb/%.js: examples_csb/%.c
+	$(EMCCSB) -I examples_csb/include $< -o $@
+
+examples_csb/%.wasm: examples_csb/%.js
+	$(NOOP)
+
 .SECONDARY:
 examples_c/%.wast: examples_c/%.wasm
 	wasm-dis $< -o $@
 
 examples_c/%: examples_c/%.c
 	$(CC) $< -o $@ -lSDL2 -lSDL2_image -lGL -lglut
+
+examples_c/%: examples_csb/%.c
+	$(CC) $< -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ CFLAGS ?= -O2
 
 EXTRA_WAC_LIBS ?=
 EXTRA_WACE_LIBS ?=
+EXTRA_WACS_LIBS ?=
 
 ##########################################################
 
@@ -16,6 +17,7 @@ EMCC = emcc $(CFLAGS) -s WASM=1 -s SIDE_MODULE=1 -s LEGALIZE_JS_FFI=0
 
 WAC_LIBS = m dl $(RL_LIBRARY) $(EXTRA_WAC_LIBS)
 WACE_LIBS = m dl $(RL_LIBRARY) SDL2 SDL2_image GL glut $(EXTRA_WACE_LIBS)
+WACS_LIBS = m dl $(RL_LIBRARY) $(EXTRA_WACS_LIBS)
 
 ifeq (,$(USE_READLINE))
     RL_LIBRARY ?= edit
@@ -47,10 +49,13 @@ wac: wac.c wa.a
 wace: wace.c wa.a
 	$(CC) -rdynamic $^ -o $@ $(foreach l,$(WACE_LIBS),-l$(l))
 
+wacs: wacs.c wa.a
+	$(CC) -rdynamic $^ -o $@ $(foreach l,$(WACS_LIBS),-l$(l))
+
 
 .PHONY:
 clean:
-	rm -f *.o *.a wac wace wace-sdl.c \
+	rm -f *.o *.a wac wace wace-sdl.c wacs \
 	    examples_c/*.js examples_c/*.html \
 	    examples_c/*.wasm examples_c/*.wast \
 	    examples_wast/*.wasm

--- a/README.md
+++ b/README.md
@@ -4,13 +4,7 @@ A Minimal WebAssembly interpreter written in C. Supports the
 WebAssembly MVP (minimum viable product) version of the WebAssembly
 specification.
 
-**This is an experimental branch that attempts to run WebAssembly code
-in a sandboxed environment. Although I like the way that wac/e 
-dynamically loads symbols, I don't particularly like that it is possible 
-to get access to *any* symbol in the host. 
-Goal: Find a way to let the host decide what symbols to expose...**
-
-There are two different builds of wac:
+There are three different builds of wac:
 
 * **wac**: (WebAssembly in C) Minimal client with an interactive REPL
   mode. Designed to run standalone wasm files compiled with
@@ -19,6 +13,10 @@ There are two different builds of wac:
 * **wace**: (WebAssembly in C with Emscripten) Client with host
   library/memory integration. Designed to run wasm code that has been
   built with Emscripten (using `-s SIDE_MODULE=1 -s LEGALIZE_JS_FFI=0`).
+* **wacs**: (WebAssembly in C, sandboxed) Client *without* host 
+  library/memory integration. Designed to run wasm code that has been
+  built with Emscripten (using `-s NO_FILESYSTEM=1 -s LEGALIZE_JS_FFI=0`).
+  Libraries must be built for wasm and statically linked to the binary.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A Minimal WebAssembly interpreter written in C. Supports the
 WebAssembly MVP (minimum viable product) version of the WebAssembly
 specification.
 
+**This is an experimental branch that attempts to run WebAssembly code
+in a sandboxed environment. Although I like the way that wac/e 
+dynamically loads symbols, I don't particularly like that it is possible 
+to get access to *any* symbol in the host. 
+Goal: Find a way to let the host decide what symbols to expose...**
+
 There are two different builds of wac:
 
 * **wac**: (WebAssembly in C) Minimal client with an interactive REPL

--- a/examples_csb/hello2.c
+++ b/examples_csb/hello2.c
@@ -2,21 +2,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <unistd.h>
-
-void memdump();
-void memdiff(size_t offset, size_t n);
-
-int test() {
-    int x = 42;
-    //printf("ABCDEFGHIJKLMNOPQRSTOVWXYZ\n", x);
-    return x;
-}
-
 int main () {
-    char *name = malloc(20);
-    memset(name, 255, 20);
-    strncpy(name, "malloc people", 15);
+    char *name;
+    name = malloc(20);
+    strncpy(name, "malloc people", 14);
     printf("hello %s\n", name);
     return 2;
 }

--- a/examples_csb/hello2.c
+++ b/examples_csb/hello2.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <unistd.h>
+
+void memdump();
+void memdiff(size_t offset, size_t n);
+
+int test() {
+    int x = 42;
+    //printf("ABCDEFGHIJKLMNOPQRSTOVWXYZ\n", x);
+    return x;
+}
+
+int main () {
+    char *name = malloc(20);
+    memset(name, 255, 20);
+    strncpy(name, "malloc people", 15);
+    printf("hello %s\n", name);
+    return 2;
+}

--- a/examples_csb/mandel.c
+++ b/examples_csb/mandel.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <complex.h>
+
+static const int n = 25;
+static const int m = 75;
+
+static const int maxiter = 100;
+
+static const double rmin = -2.1;
+static const double rmax = 0.5;
+static const double imin = -1;
+static const double imax = 1;
+
+int main( ) {
+
+    char *output = malloc(n * m);
+    memset(output, ' ', n * m);
+
+    // compute
+    for(int i=0; i<n; i++) {
+        double y = imin + (imax - imin) * i / (n - 1.0);
+        for(int j=0; j<m; j++) {
+            double x = rmin + (rmax - rmin) * j / (m - 1.0);
+
+            double complex z = 0;
+            double complex c = x + y * I;
+
+            int it = 0;
+            while((cabs(z) < 4) && (it < maxiter)) {
+                ++it;
+                z = z * z + c;
+            }
+
+            if(it >= maxiter) {
+                output[i * m + j] = '*';
+            }
+        }
+    }
+
+    // output
+    for(int i=0; i<n; i++) {
+        for(int j=0; j<m; j++) {
+            putc(output[i * m + j], stdout);
+        }
+        putc('\n', stdout);
+    }
+
+
+    free(output);
+
+    return 0;
+}

--- a/wa.c
+++ b/wa.c
@@ -1675,7 +1675,7 @@ Module *load_module(char *path, Options options, HostExport *host_exports) {
                 case 0x01:  // Table
                     ASSERT(!m->table.entries,
                            "More than 1 table not supported\n");
-                    m->table.entries = val;
+                    //m->table.entries = val;
                     warn("  setting table.entries to: %p\n", *(uint32_t **)val);
                     m->table.entries = *(uint32_t **)val;
                     break;

--- a/wa.c
+++ b/wa.c
@@ -1855,6 +1855,8 @@ Module *load_module(char *path, Options options, HostExportCallback host_export)
                      size, offset);
                 memcpy(m->memory.bytes+offset, bytes+pos, size);
                 pos += size;
+                if(offset + size > m->data_size)
+                    m->data_size = offset + size;
             }
 
             break;

--- a/wa.h
+++ b/wa.h
@@ -149,11 +149,7 @@ typedef struct Module {
 } Module;
 
 
-typedef struct HostExport {
-    struct HostExport *next;
-    const char *name;
-    void *object;
-} HostExport;
+typedef void* (*HostExportCallback)(char*, char*);
 
 //
 // Function declarations (Public API)
@@ -164,11 +160,7 @@ char *value_repr(StackValue *v);
 uint32_t get_export_fidx(Module *m, char *name);
 void (*setup_thunk_in(uint32_t fidx))();
 bool interpret(Module *m);
-Module *load_module(char *path, Options opts, HostExport *host_exports);
+Module *load_module(char *path, Options opts, HostExportCallback host_export);
 bool invoke(Module *m, char *entry, int argc, char **argv);
-
-HostExport *declare_host_export(HostExport *h, const char *name, void *object);
-void* find_host_export(HostExport *h, const char *name);
-void free_host_exports(HostExport *h);
 
 #endif // of WAC_H

--- a/wa.h
+++ b/wa.h
@@ -135,6 +135,7 @@ typedef struct Module {
     Table       table;
 
     Memory      memory;
+    uint32_t    data_size;      // size of the data segment
 
     uint32_t    global_count;   // number of globals
     StackValue *globals;        // globals

--- a/wa.h
+++ b/wa.h
@@ -148,6 +148,13 @@ typedef struct Module {
     Frame       callstack[CALLSTACK_SIZE]; // callstack
 } Module;
 
+
+typedef struct HostExport {
+    struct HostExport *next;
+    const char *name;
+    void *object;
+} HostExport;
+
 //
 // Function declarations (Public API)
 //
@@ -157,7 +164,11 @@ char *value_repr(StackValue *v);
 uint32_t get_export_fidx(Module *m, char *name);
 void (*setup_thunk_in(uint32_t fidx))();
 bool interpret(Module *m);
-Module *load_module(char *path, Options opts);
+Module *load_module(char *path, Options opts, HostExport *host_exports);
 bool invoke(Module *m, char *entry, int argc, char **argv);
+
+HostExport *declare_host_export(HostExport *h, const char *name, void *object);
+void* find_host_export(HostExport *h, const char *name);
+void free_host_exports(HostExport *h);
 
 #endif // of WAC_H

--- a/wac.c
+++ b/wac.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
 
     // Load the module
     Options opts;
-    Module *m = load_module(mod_path, opts);
+    Module *m = load_module(mod_path, opts, NULL);
 
     if (!repl) {
         // Invoke one function and exit

--- a/wace.c
+++ b/wace.c
@@ -34,6 +34,12 @@ uint32_t **_env__DYNAMICTOP_PTR_;
 uint32_t *_env__tempDoublePtr_;
 
 
+// stuff i'm not sure about...
+uint32_t _env__STACKTOP_ = 0;
+uint32_t _env__STACK_MAX_ = 0;
+
+
+
 // Initialize memory globals and function/jump table
 void emscripten_init() {
     _env__memoryBase_ = calloc(TOTAL_MEMORY, sizeof(uint8_t));
@@ -55,6 +61,7 @@ void emscripten_init() {
     _env__DYNAMICTOP_PTR_ = (uint32_t**)(_env__memoryBase_ + 16);
 
     *_env__DYNAMICTOP_PTR_ = (uint32_t*)(_env__memoryBase_ + TOTAL_MEMORY);
+
 
     info("emscripten_init results:\n");
     info("  _env__memory_: %p (0x%x)\n", _env__memory_, _env__memory_);
@@ -127,17 +134,180 @@ void _env__nullFunc_X_(uint32_t x) {
 }
 
 
+void* _env___malloc_(uint32_t size) {
+    void *m = malloc(size);
+    printf("malloc(%d) => %d \n", size, m);
+    return m;
+}
+
+#define DECLARE_DUMMY0(ret_t, name) ret_t _env__##name##_() { FATAL("Calling undefined function: %s", #name); }
+#define DECLARE_DUMMY1(ret_t, name, a1_t) ret_t _env__##name##_(a1_t a1) { FATAL("Calling undefined function: %s(%d)", #name, a1); }
+#define DECLARE_DUMMY2(ret_t, name, a1_t, a2_t) ret_t _env__##name##_(a1_t a1, a2_t a2) { FATAL("Calling undefined function: %s(%d, %d)", #name, a1, a2); }
+#define DECLARE_DUMMY3(ret_t, name, a1_t, a2_t, a3_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3) { FATAL("Calling undefined function: %s(%d, %d, %d)", #name, a1, a2, a3); }
+#define DECLARE_DUMMY4(ret_t, name, a1_t, a2_t, a3_t, a4_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3, a4_t a4) { FATAL("Calling undefined function: %s(%d, %d, %d, %d)", #name, a1, a2, a3, a4); }
+#define DECLARE_DUMMY5(ret_t, name, a1_t, a2_t, a3_t, a4_t, a5_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3, a4_t a4, a5_t a5) { FATAL("Calling undefined function: %s(%d, %d, %d, %d, %d)", #name, a1, a2, a3, a4, a5); }
+
+DECLARE_DUMMY0(int32_t, enlargeMemory)
+DECLARE_DUMMY0(int32_t, getTotalMemory)
+DECLARE_DUMMY0(int32_t, abortOnCannotGrowMemory)
+//DECLARE_DUMMYv1(abortStackOverflow, int32_t)
+
+DECLARE_DUMMY1(int32_t, invoke_i, int32_t)
+DECLARE_DUMMY2(int32_t, invoke_ii, int32_t, int32_t)
+DECLARE_DUMMY3(int32_t, invoke_iii, int32_t, int32_t, int32_t)
+DECLARE_DUMMY4(int32_t, invoke_iiii, int32_t, int32_t, int32_t, int32_t)
+DECLARE_DUMMY1(void, invoke_v, int32_t)
+DECLARE_DUMMY2(void, invoke_vi, int32_t, int32_t)
+DECLARE_DUMMY3(void, invoke_vii, int32_t, int32_t, int32_t)
+DECLARE_DUMMY4(void, invoke_viii, int32_t, int32_t, int32_t, int32_t)
+DECLARE_DUMMY5(void, invoke_viiii, int32_t, int32_t, int32_t, int32_t, int32_t)
+
+DECLARE_DUMMY2(int32_t, _pthread_cond_wait, int32_t, int32_t)
+DECLARE_DUMMY2(int32_t, _pthread_key_create, int32_t, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_rwlock_unlock, int32_t)
+DECLARE_DUMMY2(int32_t, _pthread_cond_init, int32_t, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_mutexattr_destroy, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_key_delete, int32_t)
+DECLARE_DUMMY2(int32_t, _pthread_condattr_setclock, int32_t, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_getspecific, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_rwlock_rdlock, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_cond_signal, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_mutex_destroy, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_condattr_init, int32_t)
+DECLARE_DUMMY2(int32_t, _pthread_mutexattr_settype, int32_t, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_condattr_destroy, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_mutexattr_init, int32_t)
+DECLARE_DUMMY2(int32_t, _pthread_setspecific, int32_t, int32_t)
+DECLARE_DUMMY1(int32_t, _pthread_cond_destroy, int32_t)
+DECLARE_DUMMY2(int32_t, _pthread_mutex_init, int32_t, int32_t)
+
+DECLARE_DUMMY1(void, _abort, int32_t)
+DECLARE_DUMMY3(int32_t, _emscripten_memcpy_big, int32_t, int32_t, int32_t)
+DECLARE_DUMMY1(int32_t, _getenv, int32_t)
+DECLARE_DUMMY2(int32_t, _dladdr, int32_t, int32_t)
+DECLARE_DUMMY0(void, _llvm_trap)
+
+DECLARE_DUMMY1(int32_t, __Unwind_FindEnclosingFunction, int32_t)
+DECLARE_DUMMY2(int32_t, __Unwind_GetIPInfo, int32_t, int32_t)
+DECLARE_DUMMY2(int32_t, __Unwind_Backtrace, int32_t, int32_t)
+
+//DECLARE_DUMMY5(int32_t, ___gxx_personality_v0, int32_t, int32_t, int64_t, int32_t, int32_t)
+DECLARE_DUMMY5(int32_t, ___gxx_personality_v0, int32_t, int32_t, int32_t, int32_t, int32_t)
+DECLARE_DUMMY0(int32_t, ___cxa_find_matching_catch_2)
+DECLARE_DUMMY1(int32_t, ___cxa_find_matching_catch_3, int32_t)
+DECLARE_DUMMY1(void, ___cxa_free_exception, int32_t)
+DECLARE_DUMMY3(void, ___cxa_throw, int32_t, int32_t, int32_t)
+DECLARE_DUMMY1(void, ___setErrNo, int32_t)
+DECLARE_DUMMY1(int32_t, ___cxa_allocate_exception, int32_t)
+DECLARE_DUMMY1(void, ___resumeException, int32_t)
+DECLARE_DUMMY1(void, ___unlock, int32_t)
+DECLARE_DUMMY1(void, ___lock, int32_t)
+
+DECLARE_DUMMY2(int32_t, ___syscall4, int32_t, int32_t)
+DECLARE_DUMMY2(int32_t, ___syscall6, int32_t, int32_t)
+DECLARE_DUMMY2(int32_t, ___syscall54, int32_t, int32_t)
+DECLARE_DUMMY2(int32_t, ___syscall140, int32_t, int32_t)
+DECLARE_DUMMY2(int32_t, ___syscall146, int32_t, int32_t)
+
+
+#define EXPORT(name) h = declare_host_export(h, "env." #name, &_env__##name##_)
+
+
 HostExport* exports_init() {
     HostExport *h = NULL;
     // This are the minimum exports to make the hello world examples run.
     // Of course, SDL and other stuff is broken without explicit exports.
-    h = declare_host_export(h, "env.memory", &_env__memory_);
-    h = declare_host_export(h, "env.table", &_env__table_);
-    h = declare_host_export(h, "env.memoryBase", &_env__memoryBase_);
-    h = declare_host_export(h, "env.tableBase", &_env__tableBase_);
+    EXPORT(memory);
+    EXPORT(table);
+    EXPORT(memoryBase);
+    EXPORT(tableBase);
+    //EXPORT(_puts);
     h = declare_host_export(h, "env._puts", &puts);
-    h = declare_host_export(h, "env._malloc", &malloc);
-    h = declare_host_export(h, "env._printf", &_env___printf_);
+    EXPORT(_malloc);
+    EXPORT(_printf);
+
+    // Exports required for emscripten...
+    // much todo...
+    EXPORT(DYNAMICTOP_PTR);
+    EXPORT(tempDoublePtr);
+    EXPORT(ABORT);
+    EXPORT(STACKTOP);
+    EXPORT(STACK_MAX);
+
+    EXPORT(enlargeMemory);
+    EXPORT(getTotalMemory);
+    EXPORT(abortOnCannotGrowMemory);
+    EXPORT(abortStackOverflow);
+
+    h = declare_host_export(h, "env.nullFunc_i", &_env__nullFunc_X_);
+    h = declare_host_export(h, "env.nullFunc_ii", &_env__nullFunc_X_);
+    h = declare_host_export(h, "env.nullFunc_iii", &_env__nullFunc_X_);
+    h = declare_host_export(h, "env.nullFunc_iiii", &_env__nullFunc_X_);
+    h = declare_host_export(h, "env.nullFunc_v", &_env__nullFunc_X_);
+    h = declare_host_export(h, "env.nullFunc_vi", &_env__nullFunc_X_);
+    h = declare_host_export(h, "env.nullFunc_vii", &_env__nullFunc_X_);
+    h = declare_host_export(h, "env.nullFunc_viii", &_env__nullFunc_X_);
+    h = declare_host_export(h, "env.nullFunc_viiii", &_env__nullFunc_X_);
+    h = declare_host_export(h, "env.nullFunc_ji", &_env__nullFunc_X_);
+
+    EXPORT(invoke_i);
+    EXPORT(invoke_ii);
+    EXPORT(invoke_iii);
+    EXPORT(invoke_iiii);
+    EXPORT(invoke_v);
+    EXPORT(invoke_vi);
+    EXPORT(invoke_vii);
+    EXPORT(invoke_viii);
+    EXPORT(invoke_viiii);
+
+    EXPORT(_pthread_cond_wait);
+    EXPORT(_pthread_key_create);
+    EXPORT(_pthread_rwlock_unlock);
+    EXPORT(_pthread_cond_init);
+    EXPORT(_pthread_mutexattr_destroy);
+    EXPORT(_pthread_key_delete);
+    EXPORT(_pthread_condattr_setclock);
+    EXPORT(_pthread_getspecific);
+    EXPORT(_pthread_rwlock_rdlock);
+    EXPORT(_pthread_cond_signal);
+    EXPORT(_pthread_mutex_destroy);
+    EXPORT(_pthread_condattr_init);
+    EXPORT(_pthread_mutexattr_settype);
+    EXPORT(_pthread_condattr_destroy);
+    EXPORT(_pthread_mutexattr_init);
+    EXPORT(_pthread_setspecific);
+    EXPORT(_pthread_cond_destroy);
+    EXPORT(_pthread_mutex_init);
+
+    EXPORT(_abort);
+    EXPORT(_emscripten_memcpy_big);
+    EXPORT(_getenv);
+    EXPORT(_dladdr);
+    EXPORT(_llvm_trap);
+
+    EXPORT(__Unwind_FindEnclosingFunction);
+    EXPORT(__Unwind_GetIPInfo);
+    EXPORT(__Unwind_Backtrace);
+
+    EXPORT(___gxx_personality_v0);
+    EXPORT(___cxa_find_matching_catch_2);
+    EXPORT(___cxa_find_matching_catch_3);
+    EXPORT(___cxa_free_exception);
+    EXPORT(___cxa_throw);
+    EXPORT(___setErrNo);
+    EXPORT(___cxa_allocate_exception);
+    EXPORT(___resumeException);
+    EXPORT(___unlock);
+    EXPORT(___lock);
+
+    EXPORT(___syscall4);
+    EXPORT(___syscall6);
+    EXPORT(___syscall54);
+    EXPORT(___syscall140);
+    EXPORT(___syscall146);
+
+    h = declare_host_export(h, "global.NaN", &_global__NaN_);
+    h = declare_host_export(h, "global.Infinity", &_global__Infinity_);
     return h;
 }
 

--- a/wace.c
+++ b/wace.c
@@ -19,7 +19,7 @@ void usage(char *prog) {
 // emscripten memory
 
 #define TOTAL_MEMORY  0x1000000 // 16MB
-#define TOTAL_TABLE   256
+#define TOTAL_TABLE   65536
 
 uint8_t  *_env__memory_ = 0;
 uint8_t  *_env__memoryBase_;
@@ -34,20 +34,20 @@ uint32_t **_env__DYNAMICTOP_PTR_;
 uint32_t *_env__tempDoublePtr_;
 
 
-// stuff i'm not sure about...
 uint32_t _env__STACKTOP_ = 0;
-uint32_t _env__STACK_MAX_ = 0;
+uint32_t _env__STACK_MAX_ = STACK_SIZE;  // CALLSTACK_SIZE?
 
 
 
 // Initialize memory globals and function/jump table
 void emscripten_init() {
     _env__memoryBase_ = calloc(TOTAL_MEMORY, sizeof(uint8_t));
+    _env__memory_ = _env__memoryBase_;
 
     //_env__tableBase_ = calloc(TOTAL_TABLE, sizeof(uint32_t));
 
-    //_env__table_ = calloc(TOTAL_TABLE, sizeof(uint32_t));
-    //_env__tableBase_ = 0;
+    _env__table_ = calloc(TOTAL_TABLE, sizeof(uint32_t));
+    _env__tableBase_ = _env__table_;
 
     // This arrangement correlates to the module mangle_table_offset option
     if (posix_memalign((void **)&_env__table_, sysconf(_SC_PAGESIZE),

--- a/wace.c
+++ b/wace.c
@@ -126,6 +126,21 @@ void _env__nullFunc_X_(uint32_t x) {
     FATAL("_env__nullFunc_X_ 0x%x\n", x);
 }
 
+
+HostExport* exports_init() {
+    HostExport *h = NULL;
+    // This are the minimum exports to make the hello world examples run.
+    // Of course, SDL and other stuff is broken without explicit exports.
+    h = declare_host_export(h, "env.memory", &_env__memory_);
+    h = declare_host_export(h, "env.table", &_env__table_);
+    h = declare_host_export(h, "env.memoryBase", &_env__memoryBase_);
+    h = declare_host_export(h, "env.tableBase", &_env__tableBase_);
+    h = declare_host_export(h, "env._puts", &puts);
+    h = declare_host_export(h, "env._malloc", &malloc);
+    h = declare_host_export(h, "env._printf", &_env___printf_);
+    return h;
+}
+
 /////////////////////////////////////////////////////////
 // Command line
 
@@ -136,13 +151,14 @@ int main(int argc, char **argv) {
     if (argc < 2) { usage(argv[0]); }
     mod_path = argv[1];
 
+    HostExport *exports = exports_init();
     emscripten_init();
 
     // Load the module
     Options opts = { .disable_memory_bounds = true,
                      .mangle_table_index    = true,
                      .dlsym_trim_underscore = true };
-    Module *m = load_module(mod_path, opts);
+    Module *m = load_module(mod_path, opts, exports);
 
     thunk_in_trap_init(m);
 

--- a/wace.c
+++ b/wace.c
@@ -19,7 +19,7 @@ void usage(char *prog) {
 // emscripten memory
 
 #define TOTAL_MEMORY  0x1000000 // 16MB
-#define TOTAL_TABLE   65536
+#define TOTAL_TABLE   256
 
 uint8_t  *_env__memory_ = 0;
 uint8_t  *_env__memoryBase_;
@@ -34,20 +34,14 @@ uint32_t **_env__DYNAMICTOP_PTR_;
 uint32_t *_env__tempDoublePtr_;
 
 
-uint32_t _env__STACKTOP_ = 0;
-uint32_t _env__STACK_MAX_ = STACK_SIZE;  // CALLSTACK_SIZE?
-
-
-
 // Initialize memory globals and function/jump table
 void emscripten_init() {
     _env__memoryBase_ = calloc(TOTAL_MEMORY, sizeof(uint8_t));
-    _env__memory_ = _env__memoryBase_;
 
     //_env__tableBase_ = calloc(TOTAL_TABLE, sizeof(uint32_t));
 
-    _env__table_ = calloc(TOTAL_TABLE, sizeof(uint32_t));
-    _env__tableBase_ = _env__table_;
+    //_env__table_ = calloc(TOTAL_TABLE, sizeof(uint32_t));
+    //_env__tableBase_ = 0;
 
     // This arrangement correlates to the module mangle_table_offset option
     if (posix_memalign((void **)&_env__table_, sysconf(_SC_PAGESIZE),
@@ -61,7 +55,6 @@ void emscripten_init() {
     _env__DYNAMICTOP_PTR_ = (uint32_t**)(_env__memoryBase_ + 16);
 
     *_env__DYNAMICTOP_PTR_ = (uint32_t*)(_env__memoryBase_ + TOTAL_MEMORY);
-
 
     info("emscripten_init results:\n");
     info("  _env__memory_: %p (0x%x)\n", _env__memory_, _env__memory_);
@@ -133,184 +126,6 @@ void _env__nullFunc_X_(uint32_t x) {
     FATAL("_env__nullFunc_X_ 0x%x\n", x);
 }
 
-
-void* _env___malloc_(uint32_t size) {
-    void *m = malloc(size);
-    printf("malloc(%d) => %d \n", size, m);
-    return m;
-}
-
-#define DECLARE_DUMMY0(ret_t, name) ret_t _env__##name##_() { FATAL("Calling undefined function: %s", #name); }
-#define DECLARE_DUMMY1(ret_t, name, a1_t) ret_t _env__##name##_(a1_t a1) { FATAL("Calling undefined function: %s(%d)", #name, a1); }
-#define DECLARE_DUMMY2(ret_t, name, a1_t, a2_t) ret_t _env__##name##_(a1_t a1, a2_t a2) { FATAL("Calling undefined function: %s(%d, %d)", #name, a1, a2); }
-#define DECLARE_DUMMY3(ret_t, name, a1_t, a2_t, a3_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3) { FATAL("Calling undefined function: %s(%d, %d, %d)", #name, a1, a2, a3); }
-#define DECLARE_DUMMY4(ret_t, name, a1_t, a2_t, a3_t, a4_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3, a4_t a4) { FATAL("Calling undefined function: %s(%d, %d, %d, %d)", #name, a1, a2, a3, a4); }
-#define DECLARE_DUMMY5(ret_t, name, a1_t, a2_t, a3_t, a4_t, a5_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3, a4_t a4, a5_t a5) { FATAL("Calling undefined function: %s(%d, %d, %d, %d, %d)", #name, a1, a2, a3, a4, a5); }
-
-DECLARE_DUMMY0(int32_t, enlargeMemory)
-DECLARE_DUMMY0(int32_t, getTotalMemory)
-DECLARE_DUMMY0(int32_t, abortOnCannotGrowMemory)
-//DECLARE_DUMMYv1(abortStackOverflow, int32_t)
-
-DECLARE_DUMMY1(int32_t, invoke_i, int32_t)
-DECLARE_DUMMY2(int32_t, invoke_ii, int32_t, int32_t)
-DECLARE_DUMMY3(int32_t, invoke_iii, int32_t, int32_t, int32_t)
-DECLARE_DUMMY4(int32_t, invoke_iiii, int32_t, int32_t, int32_t, int32_t)
-DECLARE_DUMMY1(void, invoke_v, int32_t)
-DECLARE_DUMMY2(void, invoke_vi, int32_t, int32_t)
-DECLARE_DUMMY3(void, invoke_vii, int32_t, int32_t, int32_t)
-DECLARE_DUMMY4(void, invoke_viii, int32_t, int32_t, int32_t, int32_t)
-DECLARE_DUMMY5(void, invoke_viiii, int32_t, int32_t, int32_t, int32_t, int32_t)
-
-DECLARE_DUMMY2(int32_t, _pthread_cond_wait, int32_t, int32_t)
-DECLARE_DUMMY2(int32_t, _pthread_key_create, int32_t, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_rwlock_unlock, int32_t)
-DECLARE_DUMMY2(int32_t, _pthread_cond_init, int32_t, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_mutexattr_destroy, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_key_delete, int32_t)
-DECLARE_DUMMY2(int32_t, _pthread_condattr_setclock, int32_t, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_getspecific, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_rwlock_rdlock, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_cond_signal, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_mutex_destroy, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_condattr_init, int32_t)
-DECLARE_DUMMY2(int32_t, _pthread_mutexattr_settype, int32_t, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_condattr_destroy, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_mutexattr_init, int32_t)
-DECLARE_DUMMY2(int32_t, _pthread_setspecific, int32_t, int32_t)
-DECLARE_DUMMY1(int32_t, _pthread_cond_destroy, int32_t)
-DECLARE_DUMMY2(int32_t, _pthread_mutex_init, int32_t, int32_t)
-
-DECLARE_DUMMY1(void, _abort, int32_t)
-DECLARE_DUMMY3(int32_t, _emscripten_memcpy_big, int32_t, int32_t, int32_t)
-DECLARE_DUMMY1(int32_t, _getenv, int32_t)
-DECLARE_DUMMY2(int32_t, _dladdr, int32_t, int32_t)
-DECLARE_DUMMY0(void, _llvm_trap)
-
-DECLARE_DUMMY1(int32_t, __Unwind_FindEnclosingFunction, int32_t)
-DECLARE_DUMMY2(int32_t, __Unwind_GetIPInfo, int32_t, int32_t)
-DECLARE_DUMMY2(int32_t, __Unwind_Backtrace, int32_t, int32_t)
-
-//DECLARE_DUMMY5(int32_t, ___gxx_personality_v0, int32_t, int32_t, int64_t, int32_t, int32_t)
-DECLARE_DUMMY5(int32_t, ___gxx_personality_v0, int32_t, int32_t, int32_t, int32_t, int32_t)
-DECLARE_DUMMY0(int32_t, ___cxa_find_matching_catch_2)
-DECLARE_DUMMY1(int32_t, ___cxa_find_matching_catch_3, int32_t)
-DECLARE_DUMMY1(void, ___cxa_free_exception, int32_t)
-DECLARE_DUMMY3(void, ___cxa_throw, int32_t, int32_t, int32_t)
-DECLARE_DUMMY1(void, ___setErrNo, int32_t)
-DECLARE_DUMMY1(int32_t, ___cxa_allocate_exception, int32_t)
-DECLARE_DUMMY1(void, ___resumeException, int32_t)
-DECLARE_DUMMY1(void, ___unlock, int32_t)
-DECLARE_DUMMY1(void, ___lock, int32_t)
-
-DECLARE_DUMMY2(int32_t, ___syscall4, int32_t, int32_t)
-DECLARE_DUMMY2(int32_t, ___syscall6, int32_t, int32_t)
-DECLARE_DUMMY2(int32_t, ___syscall54, int32_t, int32_t)
-DECLARE_DUMMY2(int32_t, ___syscall140, int32_t, int32_t)
-DECLARE_DUMMY2(int32_t, ___syscall146, int32_t, int32_t)
-
-
-#define EXPORT(name) h = declare_host_export(h, "env." #name, &_env__##name##_)
-
-
-HostExport* exports_init() {
-    HostExport *h = NULL;
-    // This are the minimum exports to make the hello world examples run.
-    // Of course, SDL and other stuff is broken without explicit exports.
-    EXPORT(memory);
-    EXPORT(table);
-    EXPORT(memoryBase);
-    EXPORT(tableBase);
-    //EXPORT(_puts);
-    h = declare_host_export(h, "env._puts", &puts);
-    EXPORT(_malloc);
-    EXPORT(_printf);
-
-    // Exports required for emscripten...
-    // much todo...
-    EXPORT(DYNAMICTOP_PTR);
-    EXPORT(tempDoublePtr);
-    EXPORT(ABORT);
-    EXPORT(STACKTOP);
-    EXPORT(STACK_MAX);
-
-    EXPORT(enlargeMemory);
-    EXPORT(getTotalMemory);
-    EXPORT(abortOnCannotGrowMemory);
-    EXPORT(abortStackOverflow);
-
-    h = declare_host_export(h, "env.nullFunc_i", &_env__nullFunc_X_);
-    h = declare_host_export(h, "env.nullFunc_ii", &_env__nullFunc_X_);
-    h = declare_host_export(h, "env.nullFunc_iii", &_env__nullFunc_X_);
-    h = declare_host_export(h, "env.nullFunc_iiii", &_env__nullFunc_X_);
-    h = declare_host_export(h, "env.nullFunc_v", &_env__nullFunc_X_);
-    h = declare_host_export(h, "env.nullFunc_vi", &_env__nullFunc_X_);
-    h = declare_host_export(h, "env.nullFunc_vii", &_env__nullFunc_X_);
-    h = declare_host_export(h, "env.nullFunc_viii", &_env__nullFunc_X_);
-    h = declare_host_export(h, "env.nullFunc_viiii", &_env__nullFunc_X_);
-    h = declare_host_export(h, "env.nullFunc_ji", &_env__nullFunc_X_);
-
-    EXPORT(invoke_i);
-    EXPORT(invoke_ii);
-    EXPORT(invoke_iii);
-    EXPORT(invoke_iiii);
-    EXPORT(invoke_v);
-    EXPORT(invoke_vi);
-    EXPORT(invoke_vii);
-    EXPORT(invoke_viii);
-    EXPORT(invoke_viiii);
-
-    EXPORT(_pthread_cond_wait);
-    EXPORT(_pthread_key_create);
-    EXPORT(_pthread_rwlock_unlock);
-    EXPORT(_pthread_cond_init);
-    EXPORT(_pthread_mutexattr_destroy);
-    EXPORT(_pthread_key_delete);
-    EXPORT(_pthread_condattr_setclock);
-    EXPORT(_pthread_getspecific);
-    EXPORT(_pthread_rwlock_rdlock);
-    EXPORT(_pthread_cond_signal);
-    EXPORT(_pthread_mutex_destroy);
-    EXPORT(_pthread_condattr_init);
-    EXPORT(_pthread_mutexattr_settype);
-    EXPORT(_pthread_condattr_destroy);
-    EXPORT(_pthread_mutexattr_init);
-    EXPORT(_pthread_setspecific);
-    EXPORT(_pthread_cond_destroy);
-    EXPORT(_pthread_mutex_init);
-
-    EXPORT(_abort);
-    EXPORT(_emscripten_memcpy_big);
-    EXPORT(_getenv);
-    EXPORT(_dladdr);
-    EXPORT(_llvm_trap);
-
-    EXPORT(__Unwind_FindEnclosingFunction);
-    EXPORT(__Unwind_GetIPInfo);
-    EXPORT(__Unwind_Backtrace);
-
-    EXPORT(___gxx_personality_v0);
-    EXPORT(___cxa_find_matching_catch_2);
-    EXPORT(___cxa_find_matching_catch_3);
-    EXPORT(___cxa_free_exception);
-    EXPORT(___cxa_throw);
-    EXPORT(___setErrNo);
-    EXPORT(___cxa_allocate_exception);
-    EXPORT(___resumeException);
-    EXPORT(___unlock);
-    EXPORT(___lock);
-
-    EXPORT(___syscall4);
-    EXPORT(___syscall6);
-    EXPORT(___syscall54);
-    EXPORT(___syscall140);
-    EXPORT(___syscall146);
-
-    h = declare_host_export(h, "global.NaN", &_global__NaN_);
-    h = declare_host_export(h, "global.Infinity", &_global__Infinity_);
-    return h;
-}
-
 /////////////////////////////////////////////////////////
 // Command line
 
@@ -321,14 +136,13 @@ int main(int argc, char **argv) {
     if (argc < 2) { usage(argv[0]); }
     mod_path = argv[1];
 
-    HostExport *exports = exports_init();
     emscripten_init();
 
     // Load the module
     Options opts = { .disable_memory_bounds = true,
                      .mangle_table_index    = true,
                      .dlsym_trim_underscore = true };
-    Module *m = load_module(mod_path, opts, exports);
+    Module *m = load_module(mod_path, opts, NULL);
 
     thunk_in_trap_init(m);
 

--- a/wacs.c
+++ b/wacs.c
@@ -145,7 +145,7 @@ int32_t syscall54(uint32_t a, uint32_t b) {
 
 int32_t syscall146(uint32_t what, uint32_t argp) {
     //printf("syscall146(%d, %p)\n", what, (void*)argp);
-    int fd = *(int32_t*)&host_memory[argp];
+    //int fd = *(int32_t*)&host_memory[argp];
     uint32_t iovecptr = *(uint32_t*)&host_memory[argp + 4];
     uint32_t iovcnt = *(uint32_t*)&host_memory[argp + 8];
     struct {

--- a/wacs.c
+++ b/wacs.c
@@ -186,6 +186,10 @@ uint32_t _env__getTotalMemory_() {
 #define DECLARE_DUMMY4(ret_t, name, a1_t, a2_t, a3_t, a4_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3, a4_t a4) { FATAL("Calling undefined function: %s(%d, %d, %d, %d)\n", #name, a1, a2, a3, a4); }
 #define DECLARE_DUMMY5(ret_t, name, a1_t, a2_t, a3_t, a4_t, a5_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3, a4_t a4, a5_t a5) { FATAL("Calling undefined function: %s(%d, %d, %d, %d, %d)\n", #name, a1, a2, a3, a4, a5); }
 
+
+
+DECLARE_DUMMY0(void, lazy_dummy)
+
 DECLARE_DUMMY1(void, nullFunc, int32_t)
 DECLARE_DUMMY2(int32_t, syscall, int32_t, int32_t)
 DECLARE_DUMMY0(int32_t, enlargeMemory)
@@ -242,6 +246,7 @@ void *exports(char *module, char *name) {
         EXPORT("abortStackOverflow", _env__abortStackOverflow_);
         EXPORT("_emscripten_memcpy_big", _env__memcpy_big_);
 
+        EXPORT("___syscall4", _env__syscall_);
         EXPORT("___syscall6", _env__syscall_);
         EXPORT("___syscall54", syscall54);
         EXPORT("___syscall91", _env__syscall_);
@@ -261,6 +266,12 @@ void *exports(char *module, char *name) {
         EXPORT("nullFunc_ii", _env__nullFunc_);
         EXPORT("nullFunc_iii", _env__nullFunc_);
         EXPORT("nullFunc_iiii", _env__nullFunc_);
+        EXPORT("nullFunc_ji", _env__nullFunc_);
+        EXPORT("nullFunc_v", _env__nullFunc_);
+        EXPORT("nullFunc_vi", _env__nullFunc_);
+        EXPORT("nullFunc_vii", _env__nullFunc_);
+        EXPORT("nullFunc_viii", _env__nullFunc_);
+        EXPORT("nullFunc_viiii", _env__nullFunc_);
 
         EXPORT("invoke_i", _env__invoke_i_);
         EXPORT("invoke_ii", _env__invoke_ii_);
@@ -282,9 +293,39 @@ void *exports(char *module, char *name) {
         EXPORT("_pthread_getspecific", _env___pthread_stuff_);
         EXPORT("_pthread_once", _env___pthread_stuff_);
         EXPORT("_pthread_setspecific", _env___pthread_stuff_);
+        EXPORT("_pthread_rwlock_unlock", _env___pthread_stuff_);
+        EXPORT("_pthread_cond_init", _env___pthread_stuff_);
+        EXPORT("_pthread_cond_destroy", _env___pthread_stuff_);
+        EXPORT("_pthread_mutexattr_destroy", _env___pthread_stuff_);
+        EXPORT("_pthread_key_delete", _env___pthread_stuff_);
+        EXPORT("_pthread_condattr_setclock", _env___pthread_stuff_);
+        EXPORT("_pthread_getspecific", _env___pthread_stuff_);
+        EXPORT("_pthread_rwlock_rdlock", _env___pthread_stuff_);
+        EXPORT("_pthread_cond_signal", _env___pthread_stuff_);
+        EXPORT("_pthread_mutex_destroy", _env___pthread_stuff_);
+        EXPORT("_pthread_condattr_init", _env___pthread_stuff_);
+        EXPORT("_pthread_condattr_destroy", _env___pthread_stuff_);
+        EXPORT("_pthread_mutexattr_settype", _env___pthread_stuff_);
+        EXPORT("_pthread_mutexattr_init", _env___pthread_stuff_);
+        EXPORT("_pthread_mutex_init", _env___pthread_stuff_);
 
         // C++ name mangled
         EXPORT("__ZSt18uncaught_exceptionv", _env___ZSt18uncaught_exceptionv_);
+
+        // Needed for Rust?
+        EXPORT("__Unwind_Backtrace", _env__lazy_dummy_);
+        EXPORT("__Unwind_FindEnclosingFunction", _env__lazy_dummy_);
+        EXPORT("__Unwind_GetIPInfo", _env__lazy_dummy_);
+        EXPORT("___gxx_personality_v0", _env__lazy_dummy_);
+        EXPORT("___cxa_find_matching_catch_2", _env__lazy_dummy_);
+        EXPORT("___cxa_find_matching_catch_3", _env__lazy_dummy_);
+        EXPORT("___cxa_free_exception", _env__lazy_dummy_);
+        EXPORT("___cxa_allocate_exception", _env__lazy_dummy_);
+        EXPORT("___cxa_throw", _env__lazy_dummy_);
+        EXPORT("___resumeException", _env__lazy_dummy_);
+        EXPORT("_dladdr", _env__lazy_dummy_);
+        EXPORT("_llvm_trap", _env__lazy_dummy_);
+
 
         // these seem to be unused
         EXPORT("ABORT", _env__zeroval_);

--- a/wacs.c
+++ b/wacs.c
@@ -45,7 +45,7 @@ void _spectest__print_(uint32_t val) {
 */
 
 typedef struct HostMemory {
-    char *memory;
+    uint8_t *memory;
     uint32_t stack_top;
     uint32_t stack_max;
     uint32_t dynamic_top;
@@ -59,10 +59,70 @@ uint32_t _env__zeroval_ = 0;
 HostMemory _memory_;
 double _temp_double_ = 0;
 
-#define DECLARE_DUMMY0(ret_t, name) ret_t _env__##name##_() { FATAL("Calling undefined function: %s", #name); }
-#define DECLARE_DUMMY1(ret_t, name, a1_t) ret_t _env__##name##_(a1_t a1) { FATAL("Calling undefined function: %s(%d)", #name, a1); }
-#define DECLARE_DUMMY2(ret_t, name, a1_t, a2_t) ret_t _env__##name##_(a1_t a1, a2_t a2) { FATAL("Calling undefined function: %s(%d, %d)", #name, a1, a2); }
-#define DECLARE_DUMMY3(ret_t, name, a1_t, a2_t, a3_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3) { FATAL("Calling undefined function: %s(%d, %d, %d)", #name, a1, a2, a3); }
+
+void print_memory(HostMemory* mem, uint32_t start, uint32_t stop) {
+    static const uint8_t colsize = 32;
+    printf("\n");
+    uint32_t m = start;
+    while(m < stop) {
+        printf("%08x  ", m);
+        for(int i=0; i<colsize; i++) {
+            printf("%02x ", mem->memory[m + i]);
+        }
+        for(int i=0; i<colsize; i++) {
+            char c = mem->memory[m + i];
+            if(c >= 32 && c < 127)
+                printf("%c", c);
+            else
+                printf(".");
+        }
+        m += colsize;
+        printf("\n");
+    }
+    printf("\n");
+
+    printf("Stack Top: %p\n", (void*)_memory_.stack_top);
+    printf("Stack Max: %p\n", (void*)_memory_.stack_max);
+    printf("Dynamic Top: %p\n", (void*)_memory_.dynamic_top);
+    printf("_env__zeroval_: %d\n", _env__zeroval_);
+    printf("_temp_double_: %f\n", _temp_double_);
+}
+
+
+int32_t syscall54(uint32_t a, uint32_t b) {
+    printf("syscall54(%d, %d)\n", a, b);
+    return 0;
+}
+
+
+int32_t syscall146(uint32_t what, uint32_t argp) {
+    int fd = *(int32_t*)&_memory_.memory[argp];
+    uint32_t iovecptr = *(uint32_t*)&_memory_.memory[argp + 4];
+    uint32_t iovcnt = *(uint32_t*)&_memory_.memory[argp + 8];
+    struct {
+        uint32_t iov_base;
+        uint32_t iov_len;
+    } *iovec;
+    int32_t total_written = 0;
+    for(uint32_t i=0; i<iovcnt; i++, iovecptr+=8) {
+        iovec = (void*)&_memory_.memory[iovecptr];
+        total_written += fwrite(&_memory_.memory[iovec->iov_base], 1, iovec->iov_len, stdout);
+    }
+    return total_written;
+}
+
+//uint32_t _env__memcpy_big_(uint32_t dst, uint32_t src, uint32_t num) {
+//    return (uint32_t)memcpy(&_memory_.memory[dst], &_memory_.memory[src], num);
+//}
+
+//void _env__nullFunc_(int32_t a) { printf("calling nullFunc(%d)\n", a);}
+
+#define DECLARE_DUMMY0(ret_t, name) ret_t _env__##name##_() { FATAL("Calling undefined function: %s\n", #name); }
+#define DECLARE_DUMMY1(ret_t, name, a1_t) ret_t _env__##name##_(a1_t a1) { FATAL("Calling undefined function: %s(%d)\n", #name, a1); }
+#define DECLARE_DUMMY2(ret_t, name, a1_t, a2_t) ret_t _env__##name##_(a1_t a1, a2_t a2) { FATAL("Calling undefined function: %s(%d, %d)\n", #name, a1, a2); }
+#define DECLARE_DUMMY3(ret_t, name, a1_t, a2_t, a3_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3) { FATAL("Calling undefined function: %s(%d, %d, %d)\n", #name, a1, a2, a3); }
+#define DECLARE_DUMMY4(ret_t, name, a1_t, a2_t, a3_t, a4_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3, a4_t a4) { FATAL("Calling undefined function: %s(%d, %d, %d, %d)\n", #name, a1, a2, a3, a4); }
+#define DECLARE_DUMMY5(ret_t, name, a1_t, a2_t, a3_t, a4_t, a5_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3, a4_t a4, a5_t a5) { FATAL("Calling undefined function: %s(%d, %d, %d, %d, %d)\n", #name, a1, a2, a3, a4, a5); }
 
 DECLARE_DUMMY1(void, nullFunc, int32_t)
 DECLARE_DUMMY2(int32_t, syscall, int32_t, int32_t)
@@ -75,6 +135,16 @@ DECLARE_DUMMY1(void, lock, int32_t)
 DECLARE_DUMMY1(void, setErrNo, int32_t)
 DECLARE_DUMMY0(void, abort)
 DECLARE_DUMMY3(int32_t, memcpy_big, int32_t, int32_t, int32_t)
+DECLARE_DUMMY1(int32_t, invoke_i, int32_t)
+DECLARE_DUMMY2(int32_t, invoke_ii, int32_t, int32_t)
+DECLARE_DUMMY3(int32_t, invoke_iii, int32_t, int32_t, int32_t)
+DECLARE_DUMMY4(int32_t, invoke_iiii, int32_t, int32_t, int32_t, int32_t)
+
+DECLARE_DUMMY1(void, invoke_v, int32_t)
+DECLARE_DUMMY2(void, invoke_vi, int32_t, int32_t)
+DECLARE_DUMMY3(void, invoke_vii, int32_t, int32_t, int32_t)
+DECLARE_DUMMY4(void, invoke_viii, int32_t, int32_t, int32_t, int32_t)
+DECLARE_DUMMY5(void, invoke_viiii, int32_t, int32_t, int32_t, int32_t, int32_t)
 
 #define EXPORT(field, obj) if(strcmp(name, field) == 0) return &obj
 
@@ -83,7 +153,7 @@ void *exports(char *module, char *name) {
     // But then, performance is unlikely to matter, here.
     if(strcmp("env", module) == 0) {
         EXPORT("memory", _memory_.memory);
-        EXPORT("table", _memory_.table);
+        EXPORT("table",  _memory_.table);
 
         EXPORT("STACKTOP", _memory_.stack_top);
         EXPORT("STACK_MAX", _memory_.stack_max);
@@ -97,18 +167,29 @@ void *exports(char *module, char *name) {
         EXPORT("_emscripten_memcpy_big", _env__memcpy_big_);
 
         EXPORT("___syscall6", _env__syscall_);
-        EXPORT("___syscall54", _env__syscall_);
+        EXPORT("___syscall54", syscall54);
         EXPORT("___syscall140", _env__syscall_);
-        EXPORT("___syscall146", _env__syscall_);
+        EXPORT("___syscall146", syscall146);
         EXPORT("___lock", _env__lock_);
         EXPORT("___unlock", _env__lock_);
         EXPORT("___setErrNo", _env__setErrNo_);
         EXPORT("_abort", _env__abort_);
+        EXPORT("abort", _env__abort_);
 
         EXPORT("nullFunc_i", _env__nullFunc_);
         EXPORT("nullFunc_ii", _env__nullFunc_);
         EXPORT("nullFunc_iii", _env__nullFunc_);
         EXPORT("nullFunc_iiii", _env__nullFunc_);
+
+        EXPORT("invoke_i", _env__invoke_i_);
+        EXPORT("invoke_ii", _env__invoke_ii_);
+        EXPORT("invoke_iii", _env__invoke_iii_);
+        EXPORT("invoke_iiii", _env__invoke_iiii_);
+        EXPORT("invoke_v", _env__invoke_v_);
+        EXPORT("invoke_vi", _env__invoke_vi_);
+        EXPORT("invoke_vii", _env__invoke_vii_);
+        EXPORT("invoke_viii", _env__invoke_viii_);
+        EXPORT("invoke_viiii", _env__invoke_viiii_);
 
         // these seem to be unused
         EXPORT("ABORT", _env__zeroval_);
@@ -160,6 +241,8 @@ int main(int argc, char **argv) {
                repl, debug, mod_path);
     }
 
+    init_memory();
+
     // Load the module
     Options opts;
     Module *m = load_module(mod_path, opts, &exports);
@@ -198,5 +281,6 @@ int main(int argc, char **argv) {
             free(tokens);
         }
     }
+    //print_memory(&_memory_, 0, 5000);
     exit(0);
 }

--- a/wacs.c
+++ b/wacs.c
@@ -313,7 +313,6 @@ void *exports(char *module, char *name) {
         EXPORT("_dladdr", _env__lazy_dummy_);
         EXPORT("_llvm_trap", _env__lazy_dummy_);
 
-
         // these seem to be unused
         EXPORT("ABORT", _env__zeroval_);
         EXPORT("memoryBase", _env__zeroval_);
@@ -372,7 +371,7 @@ int main(int argc, char **argv) {
     Options opts;
     Module *m = load_module(mod_path, opts, &exports);
 
-    uint32_t mem_start = 65536;//+ (m->data_size + 15) & -16;
+    uint32_t mem_start = (m->data_size + 15) & -16;
     _env__dynamictop_ptr_ = mem_start;
     _env__stacktop_ = mem_start + 16;
     _env__stackmax_ = _env__stacktop_ + 65536;

--- a/wacs.c
+++ b/wacs.c
@@ -368,7 +368,9 @@ int main(int argc, char **argv) {
     _env__stackmax_ = -456;
 
     // Load the module
-    Options opts;
+    Options opts = { .disable_memory_bounds = false,
+                     .mangle_table_index    = false,
+                     .dlsym_trim_underscore = false };
     Module *m = load_module(mod_path, opts, &exports);
 
     uint32_t mem_start = (m->data_size + 15) & -16;

--- a/wacs.c
+++ b/wacs.c
@@ -211,6 +211,14 @@ DECLARE_DUMMY3(void, invoke_vii, int32_t, int32_t, int32_t)
 DECLARE_DUMMY4(void, invoke_viii, int32_t, int32_t, int32_t, int32_t)
 DECLARE_DUMMY5(void, invoke_viiii, int32_t, int32_t, int32_t, int32_t, int32_t)
 
+DECLARE_DUMMY4(void, assert_fail, int32_t, int32_t, int32_t, int32_t)
+DECLARE_DUMMY5(int32_t, strftime_l, int32_t, int32_t, int32_t, int32_t, int32_t)
+DECLARE_DUMMY0(int32_t, _ZSt18uncaught_exceptionv)
+DECLARE_DUMMY1(int32_t, getenv, int32_t)
+DECLARE_DUMMY2(int32_t, __map_file, int32_t, int32_t)
+
+DECLARE_DUMMY2(int32_t, _pthread_stuff, int32_t, int32_t)
+
 #define EXPORT(field, obj) if(strcmp(name, field) == 0) return &obj
 
 void *exports(char *module, char *name) {
@@ -236,7 +244,9 @@ void *exports(char *module, char *name) {
 
         EXPORT("___syscall6", _env__syscall_);
         EXPORT("___syscall54", syscall54);
+        EXPORT("___syscall91", _env__syscall_);
         EXPORT("___syscall140", _env__syscall_);
+        EXPORT("___syscall145", _env__syscall_);
         EXPORT("___syscall146", syscall146);
         EXPORT("___lock", _env__lock_);
         EXPORT("___unlock", _env__lock_);
@@ -261,6 +271,20 @@ void *exports(char *module, char *name) {
         EXPORT("invoke_vii", _env__invoke_vii_);
         EXPORT("invoke_viii", _env__invoke_viii_);
         EXPORT("invoke_viiii", _env__invoke_viiii_);
+
+        EXPORT("___assert_fail", _env__assert_fail_);
+        EXPORT("_strftime_l", _env__strftime_l_);
+        EXPORT("_getenv", _env__getenv_);
+        EXPORT("___map_file", _env____map_file_);
+
+        EXPORT("_pthread_cond_wait", _env___pthread_stuff_);
+        EXPORT("_pthread_key_create", _env___pthread_stuff_);
+        EXPORT("_pthread_getspecific", _env___pthread_stuff_);
+        EXPORT("_pthread_once", _env___pthread_stuff_);
+        EXPORT("_pthread_setspecific", _env___pthread_stuff_);
+
+        // C++ name mangled
+        EXPORT("__ZSt18uncaught_exceptionv", _env___ZSt18uncaught_exceptionv_);
 
         // these seem to be unused
         EXPORT("ABORT", _env__zeroval_);

--- a/wacs.c
+++ b/wacs.c
@@ -1,0 +1,202 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <string.h>
+#include <math.h>
+
+#ifdef USE_READLINE
+  // WARNING: GPL license implications
+  #include <readline/readline.h>
+  #include <readline/history.h>
+#else
+  #include <editline/readline.h>
+#endif
+
+#include "util.h"
+#include "wa.h"
+
+void usage(char *prog) {
+    fprintf(stderr, "%s [--debug] WASM_FILE [--repl|-- ARG...]\n", prog);
+    exit(2);
+}
+
+// Special test imports
+uint32_t _spectest__global_ = 666;
+
+void _spectest__print_(uint32_t val) {
+    //printf("spectest.print 0x%x:i32\n", val);
+    printf("0x%x:i32\n", val);
+}
+
+#define TOTAL_MEMORY  0x1000000 // 16MB
+#define TOTAL_TABLE   65536
+
+/*  memory layout
+ *
+ *  +-------------------+
+ *  | Stack             |
+ *  | ...               |
+ *  | STACK_TOP         |
+ *  | ...               |
+ *  | STACK_MAX         |
+ *  +-------------------+
+ *  | ...               |
+ *  | DYNAMIC_TOP       |
+*/
+
+typedef struct HostMemory {
+    char *memory;
+    uint32_t stack_top;
+    uint32_t stack_max;
+    uint32_t dynamic_top;
+
+    uint32_t *table;
+} HostMemory;
+
+double    _global__NaN_         = NAN;
+double    _global__Infinity_    = INFINITY;
+uint32_t _env__zeroval_ = 0;
+HostMemory _memory_;
+double _temp_double_ = 0;
+
+#define DECLARE_DUMMY0(ret_t, name) ret_t _env__##name##_() { FATAL("Calling undefined function: %s", #name); }
+#define DECLARE_DUMMY1(ret_t, name, a1_t) ret_t _env__##name##_(a1_t a1) { FATAL("Calling undefined function: %s(%d)", #name, a1); }
+#define DECLARE_DUMMY2(ret_t, name, a1_t, a2_t) ret_t _env__##name##_(a1_t a1, a2_t a2) { FATAL("Calling undefined function: %s(%d, %d)", #name, a1, a2); }
+#define DECLARE_DUMMY3(ret_t, name, a1_t, a2_t, a3_t) ret_t _env__##name##_(a1_t a1, a2_t a2, a3_t a3) { FATAL("Calling undefined function: %s(%d, %d, %d)", #name, a1, a2, a3); }
+
+DECLARE_DUMMY1(void, nullFunc, int32_t)
+DECLARE_DUMMY2(int32_t, syscall, int32_t, int32_t)
+DECLARE_DUMMY0(int32_t, enlargeMemory)
+DECLARE_DUMMY0(int32_t, getTotalMemory)
+DECLARE_DUMMY0(int32_t, abortOnCannotGrowMemory)
+DECLARE_DUMMY1(void, abortStackOverflow, int32_t)
+DECLARE_DUMMY1(void, unlock, int32_t)
+DECLARE_DUMMY1(void, lock, int32_t)
+DECLARE_DUMMY1(void, setErrNo, int32_t)
+DECLARE_DUMMY0(void, abort)
+DECLARE_DUMMY3(int32_t, memcpy_big, int32_t, int32_t, int32_t)
+
+#define EXPORT(field, obj) if(strcmp(name, field) == 0) return &obj
+
+void *exports(char *module, char *name) {
+    // This is rather crude... a hashtable would be nicer.
+    // But then, performance is unlikely to matter, here.
+    if(strcmp("env", module) == 0) {
+        EXPORT("memory", _memory_.memory);
+        EXPORT("table", _memory_.table);
+
+        EXPORT("STACKTOP", _memory_.stack_top);
+        EXPORT("STACK_MAX", _memory_.stack_max);
+        EXPORT("DYNAMICTOP_PTR", _memory_.dynamic_top);
+        EXPORT("tempDoublePtr", _temp_double_);
+
+        EXPORT("enlargeMemory", _env__enlargeMemory_);
+        EXPORT("getTotalMemory", _env__getTotalMemory_);
+        EXPORT("abortOnCannotGrowMemory", _env__abortOnCannotGrowMemory_);
+        EXPORT("abortStackOverflow", _env__abortStackOverflow_);
+        EXPORT("_emscripten_memcpy_big", _env__memcpy_big_);
+
+        EXPORT("___syscall6", _env__syscall_);
+        EXPORT("___syscall54", _env__syscall_);
+        EXPORT("___syscall140", _env__syscall_);
+        EXPORT("___syscall146", _env__syscall_);
+        EXPORT("___lock", _env__lock_);
+        EXPORT("___unlock", _env__lock_);
+        EXPORT("___setErrNo", _env__setErrNo_);
+        EXPORT("_abort", _env__abort_);
+
+        EXPORT("nullFunc_i", _env__nullFunc_);
+        EXPORT("nullFunc_ii", _env__nullFunc_);
+        EXPORT("nullFunc_iii", _env__nullFunc_);
+        EXPORT("nullFunc_iiii", _env__nullFunc_);
+
+        // these seem to be unused
+        EXPORT("ABORT", _env__zeroval_);
+        EXPORT("memoryBase", _env__zeroval_);
+        EXPORT("tableBase", _env__zeroval_);
+    }
+    if(strcmp("global", module) == 0) {
+        EXPORT("NaN", _global__NaN_);
+        EXPORT("Infinity", _global__Infinity_);
+    }
+    return NULL;
+}
+
+
+void init_memory() {
+    _memory_.memory = calloc(TOTAL_MEMORY, sizeof(char));
+    _memory_.stack_top = 0;
+    _memory_.stack_max = STACK_SIZE;
+    _memory_.dynamic_top = STACK_SIZE + 1;
+
+    _memory_.table = calloc(TOTAL_TABLE, sizeof(uint32_t));
+}
+
+
+int main(int argc, char **argv) {
+    char   *mod_path, *entry, *line;
+    int     repl = 0, debug = 0, res = 0;
+
+    // Parse arguments
+    int option_index = 0, c;
+    struct option long_options[] = {
+        {"repl",  no_argument, &repl,  1},
+        {"debug", no_argument, &debug, 1},
+        {0,       0,           0,      0}
+    };
+    while ((c = getopt_long (argc, argv, "",
+                             long_options, &option_index)) != -1) {
+        switch (c) {
+        case 0: break;
+        case '?': usage(argv[0]); break;
+        default: usage(argv[0]);
+        }
+    }
+    if (optind >= argc) { usage(argv[0]); }
+    mod_path = argv[optind++];
+
+    if (debug) {
+        printf("repl: %d, debug: %d, module path: %s\n",
+               repl, debug, mod_path);
+    }
+
+    // Load the module
+    Options opts;
+    Module *m = load_module(mod_path, opts, &exports);
+
+    if (!repl) {
+        // Invoke one function and exit
+        res = invoke(m, argv[optind], argc-optind-1, argv+optind+1);
+        if (res) {
+	    if (m->sp >= 0) {
+		printf("%s\n", value_repr(&m->stack[m->sp]));
+	    }
+        } else {
+	    error("Exception: %s\n", exception);
+	    exit(1);
+	}
+    } else {
+        // Simple REPL
+        if (optind < argc) { usage(argv[0]); }
+        while (line = readline("webassembly> ")) {
+            int token_cnt = 0;
+            char **tokens = split_string(line, &token_cnt);
+            if (token_cnt == 0) { continue; }
+
+            // Reset the stacks
+            m->sp = -1;
+            m->fp = -1;
+            m->csp = -1;
+            res = invoke(m, tokens[0], token_cnt-1, tokens+1);
+	    if (res) {
+		if (m->sp >= 0) {
+		    printf("%s\n", value_repr(&m->stack[m->sp]));
+		}
+	    } else {
+		error("Exception: %s\n", exception);
+	    }
+            free(tokens);
+        }
+    }
+    exit(0);
+}


### PR DESCRIPTION
I have implemented restricted exports as discussed in #2.

I tried to keep changes to core `wac` minimal. If an optional callback is passed to `load_module` it is used to look up imports. If `NULL` is passed the symbols are resolved as usual. This implies a small API change because default arguments and function overloading is not available in C, if I am not mistaken.

These are quite a bunch of commits, some of them a bit tangential to the final result. I can squash them together if necessary.