### PR TITLE
Fix grow_memory units

### DIFF
--- a/wa.c
+++ b/wa.c
@@ -887,7 +887,7 @@ bool interpret(Module *m) {
             m->memory.bytes = arecalloc(m->memory.bytes,
                                         prev_pages*PAGE_SIZE,
                                         m->memory.pages*PAGE_SIZE,
-                                        sizeof(uint32_t),
+                                        sizeof(uint8_t),
                                         "Module->memory.bytes");
             continue;
 


### PR DESCRIPTION
I noticed this while measuring Wac's RAM usage. Great project by the way.

The allocated RAM was quadrupling when Wac hit a grow_memory instruction. It looks like the wrong allocation unit may have been used? Later in wa.c in load_module I noticed a uint8_t was used there suggesting this was a typo.