### PR TITLE
docs: fix simple typo, lirary -> library

### DIFF
--- a/platform_libc.c
+++ b/platform_libc.c
@@ -33,7 +33,7 @@ void *arecalloc(void *ptr, size_t old_nmemb, size_t nmemb,
 }
 
 //
-// Some extra lirary routines
+// Some extra library routines
 //
 
 // open and mmap a file


### PR DESCRIPTION
There is a small typo in platform_libc.c.

Should read `library` rather than `lirary`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md